### PR TITLE
Update for pre-built docker images

### DIFF
--- a/roles/transientbug-docker/tasks/main.yml
+++ b/roles/transientbug-docker/tasks/main.yml
@@ -32,11 +32,22 @@
     AWS_ACCESS_KEY_ID: "{{ lookup('env', 'AWS_ACCESS_KEY_ID') }}"
     AWS_SECRET_ACCESS_KEY: "{{ lookup('env', 'AWS_SECRET_ACCESS_KEY') }}"
 
+- name: "Cleaning up public/"
+  file:
+    path: /opt/transientbug/public/
+    state: absent
+
 - name: "Unpacking compiled package"
   unarchive:
     remote_src: true
     src: /opt/transientbug/current_package.tar.gz
     dest: /opt/transientbug/
+
+- name: "Logging into GitHub docker registry"
+  command: docker login docker.pkg.github.com --username $DOCKER_USERNAME --password $DOCKER_PASSWORD
+  environment:
+    DOCKER_USERNAME: "{{ lookup('env', 'DOCKER_USERNAME') }}"
+    DOCKER_PASSWORD: "{{ lookup('env', 'DOCKER_PASSWORD') }}"
 
 - name: "Building new docker-compose stack"
   command: docker-compose build


### PR DESCRIPTION
Updates the flow to clean `public/` up to avoid stale sprockets manifests which has been causing some asset regressions.

Also Log into the GitHub package registry with docker to pull the new pre-built images for each service to go along with https://github.com/transientBug/transientbug-rails/pull/114